### PR TITLE
LIBAVALON-203. Modifed expiration date validation in AccessToken

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -82,6 +82,9 @@ class AccessToken < ApplicationRecord
 
   # Validation method to check whether the expiration is in the future
   def expiration_must_be_future
+    # Need to skip check after token is expired, so "expired" flag can be set
+    # by the "cleanup access token" job
+    return if expired? 
     errors.add(:expiration, 'is in the past') unless expiration.future?
   end
 


### PR DESCRIPTION
Modified the "expiration_must_be_future" in the "AccessToken"
model, so that it is skipped if the token is expired. This is
needed because the "CleanupAccessTokenJob" needs to be able
to modify the token (to set the "expired" flag) after the
expiration date is past.

https://issues.umd.edu/browse/LIBAVALON-203