### PR TITLE
LIBAVALON-238. Updated Ability tests for streaming ability

### DIFF
--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -152,49 +152,231 @@ describe Ability, type: :model do
   end
 
   describe "stream Ability" do
-    let(:media_object) { FactoryBot.create(:media_object) }
+    context 'when media object is unpublished' do
+      let(:unpublished_media_object) { FactoryBot.create(:media_object) }
 
-    it 'is not available to non-logged in users' do
-      ability = Ability.new(nil)
-      expect(ability).to_not be_able_to(:stream, media_object)
-    end
+      it 'is not streamable by non-logged in users' do
+        ability = Ability.new(nil)
+        expect(ability).to_not be_able_to(:stream, unpublished_media_object)
+      end
 
-    it 'is available to admin users' do
-      ability = Ability.new(FactoryBot.create(:admin))
-      expect(ability).to be_able_to(:stream, media_object)
-    end
+      it 'is not streamable by ordinary logged in users' do
+        ability = Ability.new(FactoryBot.create(:public))
+        expect(ability).to_not be_able_to(:stream, unpublished_media_object)
+      end
 
-    it 'is available to managers, editors, and depositors of the collection' do
-      collection_users = media_object.collection.managers +
-                         media_object.collection.editors +
-                         media_object.collection.depositors
-      collection_users.each do |user_name|
-        ability = Ability.new(User.find_by(username: user_name))
-        expect(ability).to be_able_to(:stream, media_object)
+      it 'is streamable by admin users' do
+        ability = Ability.new(FactoryBot.create(:admin))
+        expect(ability).to be_able_to(:stream, unpublished_media_object)
+      end
+
+      it 'is streamable by managers, editors, and depositors of the collection' do
+        collection_users = unpublished_media_object.collection.managers +
+                          unpublished_media_object.collection.editors +
+                          unpublished_media_object.collection.depositors
+        collection_users.each do |user_name|
+          ability = Ability.new(User.find_by(username: user_name))
+          expect(ability).to be_able_to(:stream, unpublished_media_object)
+        end
+      end
+
+      it 'is not streamable by managers, editors, and depositors of other collections' do
+        other_collection = FactoryBot.create(:collection)
+
+        other_collection_users = other_collection.managers +
+                                other_collection.editors +
+                                other_collection.depositors
+
+        other_collection_users.each do |user_name|
+          ability = Ability.new(User.find_by(username: user_name))
+          expect(ability).to_not be_able_to(:stream, unpublished_media_object)
+        end
+      end
+
+      it 'is not streamable even if an active access token allowing streaming is provided' do
+        # Access token does not allow streaming because media object is unpublished
+        access_token = FactoryBot.create(:access_token, :allow_streaming)
+        access_token.media_object_id = unpublished_media_object.id
+        access_token.save!
+
+        token = access_token.token
+        ability = Ability.new(nil, { access_token: token })
+        expect(ability).to_not be_able_to(:stream, unpublished_media_object)
       end
     end
 
-    it 'is not available to managers, editors, and depositors of other collections' do
-      other_collection = FactoryBot.create(:collection)
+    context 'when media object is published' do
+      let(:published_media_object) { FactoryBot.create(:published_media_object) }
+      context 'and item access (visibility) is "private"' do
+        before(:each) do
+          published_media_object.visibility = 'private'
+          published_media_object.save!
+          published_media_object.reload
+          expect(published_media_object.visibility).to eq('private')
+        end
 
-      other_collection_users = other_collection.managers +
-                              other_collection.editors +
-                              other_collection.depositors
+        it 'is not streamable by non-logged in users' do
+          ability = Ability.new(nil)
+          expect(ability).to_not be_able_to(:stream, published_media_object)
+        end
 
-      other_collection_users.each do |user_name|
-        ability = Ability.new(User.find_by(username: user_name))
-        expect(ability).to_not be_able_to(:stream, media_object)
+        it 'is not streamable by ordinary logged in users' do
+          ability = Ability.new(FactoryBot.create(:public))
+          expect(ability).to_not be_able_to(:stream, published_media_object)
+        end
+
+        it 'is streamable by admin users' do
+          ability = Ability.new(FactoryBot.create(:admin))
+          expect(ability).to be_able_to(:stream, published_media_object)
+        end
+
+        it 'is streamable by managers, editors, and depositors of the collection' do
+          collection_users = published_media_object.collection.managers +
+                            published_media_object.collection.editors +
+                            published_media_object.collection.depositors
+          collection_users.each do |user_name|
+            ability = Ability.new(User.find_by(username: user_name))
+            expect(ability).to be_able_to(:stream, published_media_object)
+          end
+        end
+
+        it 'is not streamable by managers, editors, and depositors of other collections' do
+          other_collection = FactoryBot.create(:collection)
+
+          other_collection_users = other_collection.managers +
+                                  other_collection.editors +
+                                  other_collection.depositors
+
+          other_collection_users.each do |user_name|
+            ability = Ability.new(User.find_by(username: user_name))
+            expect(ability).to_not be_able_to(:stream, published_media_object)
+          end
+        end
+
+        it 'is streamable if an active access token allowing streaming is provided' do
+          access_token = FactoryBot.create(:access_token, :allow_streaming)
+          access_token.media_object_id = published_media_object.id
+          access_token.save!
+
+          token = access_token.token
+          ability = Ability.new(nil, { access_token: token })
+          expect(ability).to be_able_to(:stream, published_media_object)
+        end
       end
-    end
 
-    it 'is available if an active access token allowing streaming is provided' do
-      access_token = FactoryBot.create(:access_token, :allow_streaming)
-      access_token.media_object_id = media_object.id
-      access_token.save!
+      context 'and item access (visibility) is "restricted" (to logged in users)' do
+        before(:each) do
+          published_media_object.visibility = 'restricted'
+          published_media_object.save!
+          published_media_object.reload
+          expect(published_media_object.visibility).to eq('restricted')
+        end
 
-      token = access_token.token
-      ability = Ability.new(nil, { access_token: token })
-      expect(ability).to be_able_to(:stream, media_object)
+        it 'is not streamable by non-logged in users' do
+          ability = Ability.new(nil)
+          expect(ability).to_not be_able_to(:stream, published_media_object)
+        end
+
+        it 'is streamable by ordinary logged in users' do
+          ability = Ability.new(FactoryBot.create(:public))
+          expect(ability).to be_able_to(:stream, published_media_object)
+        end
+
+        it 'is streamable by admin users' do
+          ability = Ability.new(FactoryBot.create(:admin))
+          expect(ability).to be_able_to(:stream, published_media_object)
+        end
+
+        it 'is streamable by managers, editors, and depositors of the collection' do
+          collection_users = published_media_object.collection.managers +
+                            published_media_object.collection.editors +
+                            published_media_object.collection.depositors
+          collection_users.each do |user_name|
+            ability = Ability.new(User.find_by(username: user_name))
+            expect(ability).to be_able_to(:stream, published_media_object)
+          end
+        end
+
+        it 'is streamable by managers, editors, and depositors of other collections' do
+          other_collection = FactoryBot.create(:collection)
+
+          other_collection_users = other_collection.managers +
+                                  other_collection.editors +
+                                  other_collection.depositors
+
+          other_collection_users.each do |user_name|
+            ability = Ability.new(User.find_by(username: user_name))
+            expect(ability).to be_able_to(:stream, published_media_object)
+          end
+        end
+
+        it 'is streamable if an active access token allowing streaming is provided' do
+          access_token = FactoryBot.create(:access_token, :allow_streaming)
+          access_token.media_object_id = published_media_object.id
+          access_token.save!
+
+          token = access_token.token
+          ability = Ability.new(nil, { access_token: token })
+          expect(ability).to be_able_to(:stream, published_media_object)
+        end
+      end
+
+      context 'and item access (visibility) is "public"' do
+        before(:each) do
+          published_media_object.visibility = 'public'
+          published_media_object.save!
+          published_media_object.reload
+          expect(published_media_object.visibility).to eq('public')
+        end
+
+        it 'is streamable by non-logged in users' do
+          ability = Ability.new(nil)
+          expect(ability).to be_able_to(:stream, published_media_object)
+        end
+
+        it 'is streamable by ordinary logged in users' do
+          ability = Ability.new(FactoryBot.create(:public))
+          expect(ability).to be_able_to(:stream, published_media_object)
+        end
+
+        it 'is streamable by admin users' do
+          ability = Ability.new(FactoryBot.create(:admin))
+          expect(ability).to be_able_to(:stream, published_media_object)
+        end
+
+        it 'is streamable by managers, editors, and depositors of the collection' do
+          collection_users = published_media_object.collection.managers +
+                            published_media_object.collection.editors +
+                            published_media_object.collection.depositors
+          collection_users.each do |user_name|
+            ability = Ability.new(User.find_by(username: user_name))
+            expect(ability).to be_able_to(:stream, published_media_object)
+          end
+        end
+
+        it 'is streamable by managers, editors, and depositors of other collections' do
+          other_collection = FactoryBot.create(:collection)
+
+          other_collection_users = other_collection.managers +
+                                  other_collection.editors +
+                                  other_collection.depositors
+
+          other_collection_users.each do |user_name|
+            ability = Ability.new(User.find_by(username: user_name))
+            expect(ability).to be_able_to(:stream, published_media_object)
+          end
+        end
+
+        it 'is streamable if an active access token allowing streaming is provided' do
+          access_token = FactoryBot.create(:access_token, :allow_streaming)
+          access_token.media_object_id = published_media_object.id
+          access_token.save!
+
+          token = access_token.token
+          ability = Ability.new(nil, { access_token: token })
+          expect(ability).to be_able_to(:stream, published_media_object)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Expanded the "spec/models/ability_spec.rb" tests for streaming to
cover unpublished/published media objects, and (for published media
objects) whether the media object's item access is private, restricted,
or public.

When an access token is provided, a media object is only streamable
if it is published. Having an access token does not provide streaming
access to an unpublished media object.

These tests attempt to codify the permissions outlined in
https://confluence.umd.edu/pages/viewpage.action?pageId=635241505

https://issues.umd.edu/browse/LIBAVALON-238